### PR TITLE
Refactor: Select폴더 분리

### DIFF
--- a/src/components/common/searchbar/SearchBar.jsx
+++ b/src/components/common/searchbar/SearchBar.jsx
@@ -1,54 +1,26 @@
 import {
   SearchBarContainer,
   StyledSearchBar,
-  StyledSelect,
-  Selected,
-  SelectedValue,
-  Arrow,
-  Options,
-  Option,
 } from "./Searchbar.style";
 import { useState } from "react";
-import { ChevronUpIcon, ChevronDownIcon } from "@/assets/svg/icons";
+import Select from "./Select";
 const SearchBar = () => {
-  const [selected, setSelected] = useState("최신순");
-  const [showOptions, setShowOptions] = useState(false);
-  const handleClickOptions = () => {
-    setShowOptions(!showOptions);
-  };
-  const handleOptionClick = (option) => {
-    setSelected(option);
-    setShowOptions(false);
-  };
+  const [selected, setSelected] =
+    useState("최신순");
+  const searchOptions = [
+    "최신순",
+    "조회수순",
+    "댓글순",
+    "좋아요순",
+  ];
   return (
     <SearchBarContainer>
       <StyledSearchBar placeholder="제목, 내용을 입력해주세요"></StyledSearchBar>
-      <StyledSelect>
-        <Selected onClick={handleClickOptions}>
-          <SelectedValue>{selected}</SelectedValue>
-          <Arrow>
-            {showOptions ? (
-              <ChevronUpIcon width="16" height="12" class="bi bi-chevron-up" />
-            ) : (
-              <ChevronDownIcon
-                width="16"
-                height="12"
-                class="bi bi-chevron-down"
-              />
-            )}
-          </Arrow>
-        </Selected>
-        <Options active={showOptions}>
-          <Option onClick={() => handleOptionClick("최신순")}>최신순</Option>
-          <Option onClick={() => handleOptionClick("조회수순")}>
-            조회수순
-          </Option>
-          <Option onClick={() => handleOptionClick("댓글순")}>댓글순</Option>
-          <Option onClick={() => handleOptionClick("좋아요순")}>
-            좋아요순
-          </Option>
-        </Options>
-      </StyledSelect>
+      <Select
+        options={searchOptions}
+        selectedValue={selected}
+        setSelectedValue={setSelected}
+      />
     </SearchBarContainer>
   );
 };

--- a/src/components/common/searchbar/Select.jsx
+++ b/src/components/common/searchbar/Select.jsx
@@ -1,0 +1,67 @@
+import {
+  SearchBarContainer,
+  StyledSearchBar,
+  StyledSelect,
+  Selected,
+  SelectedValue,
+  Arrow,
+  Options,
+  Option,
+} from "./Searchbar.style";
+import { useState } from "react";
+import {
+  ChevronUpIcon,
+  ChevronDownIcon,
+} from "@/assets/svg/icons";
+const Select = ({
+  options,
+  selectedValue,
+  setSelectedValue,
+}) => {
+  const [showOptions, setShowOptions] =
+    useState(false);
+  const handleClickOptions = () => {
+    setShowOptions(!showOptions);
+  };
+  const handleOptionClick = (option) => {
+    setSelectedValue(option);
+    setShowOptions(false);
+  };
+  return (
+    <StyledSelect>
+      <Selected onClick={handleClickOptions}>
+        <SelectedValue>
+          {selectedValue}
+        </SelectedValue>
+        <Arrow>
+          {showOptions ? (
+            <ChevronUpIcon
+              width="16"
+              height="12"
+              class="bi bi-chevron-up"
+            />
+          ) : (
+            <ChevronDownIcon
+              width="16"
+              height="12"
+              class="bi bi-chevron-down"
+            />
+          )}
+        </Arrow>
+      </Selected>
+      <Options active={showOptions}>
+        {options.map((option, index) => (
+          <Option
+            key={index}
+            onClick={() =>
+              handleOptionClick(option)
+            }
+          >
+            {option}
+          </Option>
+        ))}
+      </Options>
+    </StyledSelect>
+  );
+};
+export default Select;


### PR DESCRIPTION
### #️⃣연관된 이슈

- resolve #33

### 📝상세 내용

- Searchbar.jsx에서 Select분리
- Select에 prop으로 options, selectedValue, setSelectedValue를 전해줌으로써 코드 짧게 가능
