### PR TITLE
FEAT: 페이지네이션 구현 + 커뮤니티url쿼리스트링 설정

### DIFF
--- a/src/apis/apiConstants.js
+++ b/src/apis/apiConstants.js
@@ -15,7 +15,7 @@ export const END_POINT = {
   COMMUNITY_CONCERN_ARTICLE: (articleId) =>
     `consulting/${articleId}`,
 
-  COMMUNITY_QUENTION: "question",
+  COMMUNITY_QUESTION: "question",
   COMMUNITY_QUESTION_ARTICLE: (articleId) =>
     `question/${articleId}`,
 

--- a/src/components/common/pagination/pagination.jsx
+++ b/src/components/common/pagination/pagination.jsx
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react";
+import { Flex } from "@components/common/flex/Flex";
+import Button from "@components/common/button/Button";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "@assets/svg/icons";
+import {
+  PageList,
+  ActiveButton,
+} from "./Pagination.style.js";
+const Pagination = ({
+  totalItems,
+  itemCountPerPage,
+  pageCount,
+  currentPage,
+}) => {
+  const totalPages = Math.ceil(
+    totalItems / itemCountPerPage
+  );
+  const [start, setStart] = useState(1);
+  const noPrev = start === 1;
+  const noNext = start + pageCount >= totalPages;
+  useEffect(() => {
+    if (currentPage === start + pageCount) {
+      setStart((prev) => prev + pageCount);
+    }
+    if (currentPage < start)
+      setStart((prev) => prev - pageCount);
+  }, [currentPage, pageCount, start]);
+
+  return (
+    <Flex
+      justify="center"
+      align="center"
+      marginTop="30px"
+    >
+      <PageList>
+        {!noPrev && (
+          <li>
+            <Button text>
+              <ChevronLeftIcon
+                width="16"
+                height="16"
+              />
+            </Button>
+          </li>
+        )}
+        {[...Array(pageCount)].map((a, idx) => (
+          <>
+            {start + idx <= totalPages && (
+              <li key={idx}>
+                {currentPage === start + idx ? (
+                  <ActiveButton text>
+                    {start + idx}
+                  </ActiveButton>
+                ) : (
+                  <Button text>
+                    {start + idx}
+                  </Button>
+                )}
+              </li>
+            )}
+          </>
+        ))}
+        {!noNext && (
+          <li>
+            <Button text>
+              <ChevronRightIcon
+                width="16"
+                height="16"
+              />
+            </Button>
+          </li>
+        )}
+      </PageList>
+    </Flex>
+  );
+};
+export default Pagination;

--- a/src/components/common/pagination/pagination.jsx
+++ b/src/components/common/pagination/pagination.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from "react";
 import { Flex } from "@components/common/flex/Flex";
 import Button from "@components/common/button/Button";
+import { Link } from "react-router-dom";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from "@assets/svg/icons";
+import { PATH } from "@router/Constants";
 import {
   PageList,
   ActiveButton,
@@ -14,13 +16,16 @@ const Pagination = ({
   itemCountPerPage,
   pageCount,
   currentPage,
+  type,
+  link,
 }) => {
   const totalPages = Math.ceil(
     totalItems / itemCountPerPage
   );
   const [start, setStart] = useState(1);
   const noPrev = start === 1;
-  const noNext = start + pageCount >= totalPages;
+  const noNext =
+    start + pageCount - 1 >= totalPages;
   useEffect(() => {
     if (currentPage === start + pageCount) {
       setStart((prev) => prev + pageCount);
@@ -37,41 +42,56 @@ const Pagination = ({
     >
       <PageList>
         {!noPrev && (
-          <li>
-            <Button text>
-              <ChevronLeftIcon
-                width="16"
-                height="16"
-              />
-            </Button>
-          </li>
+          <Link
+            to={link + `&pageNo=${start - 1}`}
+          >
+            <li>
+              <Button text>
+                <ChevronLeftIcon
+                  width="16"
+                  height="16"
+                />
+              </Button>
+            </li>
+          </Link>
         )}
         {[...Array(pageCount)].map((a, idx) => (
           <>
-            {start + idx <= totalPages && (
-              <li key={idx}>
-                {currentPage === start + idx ? (
-                  <ActiveButton text>
-                    {start + idx}
-                  </ActiveButton>
-                ) : (
-                  <Button text>
-                    {start + idx}
-                  </Button>
-                )}
-              </li>
-            )}
+            <Link
+              to={link + `&pageNo=${start + idx}`}
+            >
+              {start + idx <= totalPages && (
+                <li key={idx}>
+                  {currentPage === start + idx ? (
+                    <ActiveButton text>
+                      {start + idx}
+                    </ActiveButton>
+                  ) : (
+                    <Button text>
+                      {start + idx}
+                    </Button>
+                  )}
+                </li>
+              )}
+            </Link>
           </>
         ))}
         {!noNext && (
-          <li>
-            <Button text>
-              <ChevronRightIcon
-                width="16"
-                height="16"
-              />
-            </Button>
-          </li>
+          <Link
+            to={
+              link +
+              `&pageNo=${start + pageCount}`
+            }
+          >
+            <li>
+              <Button text>
+                <ChevronRightIcon
+                  width="16"
+                  height="16"
+                />
+              </Button>
+            </li>
+          </Link>
         )}
       </PageList>
     </Flex>

--- a/src/components/common/pagination/pagination.style.js
+++ b/src/components/common/pagination/pagination.style.js
@@ -1,0 +1,13 @@
+import { styled } from "styled-components";
+import Button from "@components/common/button/Button";
+export const PageList = styled.ul`
+  list-style: none;
+  display: flex;
+  //   flex-direction: column
+  gap: 0.5rem;
+`;
+export const ActiveButton = styled(Button)`
+  width: 3rem;
+  background-color: black;
+  color: white;
+`;

--- a/src/components/common/searchbar/SearchBar.jsx
+++ b/src/components/common/searchbar/SearchBar.jsx
@@ -2,13 +2,17 @@ import {
   SearchBarContainer,
   StyledSearchBar,
 } from "./Searchbar.style";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Select from "@components/common/select/Select";
 import useCommonStore from "@/stores/common/CommonStore";
 import { useNavigate } from "react-router-dom";
 const SearchBar = ({ link }) => {
   const [selected, setSelected] =
     useState("최신순");
+  const [
+    pendingNavigation,
+    setPendingNavigation,
+  ] = useState(false);
   const navigate = useNavigate();
   const searchOptions = [
     "최신순",
@@ -24,9 +28,16 @@ const SearchBar = ({ link }) => {
       e.nativeEvent.isComposing === false
     ) {
       setKeyword(e.target.value);
-      navigate(link);
+      setPendingNavigation(true);
+      e.preventDefault();
     }
   };
+  useEffect(() => {
+    if (pendingNavigation) {
+      navigate(link);
+      setPendingNavigation(false);
+    }
+  }, [pendingNavigation, navigate, link]);
   return (
     <SearchBarContainer>
       <StyledSearchBar
@@ -38,6 +49,7 @@ const SearchBar = ({ link }) => {
         selectedValue={selected}
         setSelectedValue={setSelected}
         width={"6rem"}
+        link={link}
       />
     </SearchBarContainer>
   );

--- a/src/components/common/searchbar/SearchBar.jsx
+++ b/src/components/common/searchbar/SearchBar.jsx
@@ -1,12 +1,38 @@
-import { SearchBarContainer, StyledSearchBar } from "./Searchbar.style";
+import {
+  SearchBarContainer,
+  StyledSearchBar,
+} from "./Searchbar.style";
 import { useState } from "react";
 import Select from "@components/common/select/Select";
-const SearchBar = () => {
-  const [selected, setSelected] = useState("최신순");
-  const searchOptions = ["최신순", "조회수순", "댓글순", "좋아요순"];
+import useCommonStore from "@/stores/common/CommonStore";
+import { useNavigate } from "react-router-dom";
+const SearchBar = ({ link }) => {
+  const [selected, setSelected] =
+    useState("최신순");
+  const navigate = useNavigate();
+  const searchOptions = [
+    "최신순",
+    "조회수순",
+    "댓글순",
+    "좋아요순",
+  ];
+  const { keyword, setKeyword } =
+    useCommonStore();
+  const handleKeyDown = (e) => {
+    if (
+      e.key === "Enter" &&
+      e.nativeEvent.isComposing === false
+    ) {
+      setKeyword(e.target.value);
+      navigate(link);
+    }
+  };
   return (
     <SearchBarContainer>
-      <StyledSearchBar placeholder="제목, 내용을 입력해주세요"></StyledSearchBar>
+      <StyledSearchBar
+        placeholder="제목, 내용을 입력해주세요"
+        onKeyDown={handleKeyDown}
+      ></StyledSearchBar>
       <Select
         options={searchOptions}
         selectedValue={selected}

--- a/src/components/common/select/Select.jsx
+++ b/src/components/common/select/Select.jsx
@@ -1,5 +1,9 @@
-import { useState } from "react";
-import { ChevronUpIcon, ChevronDownIcon } from "@/assets/svg/icons";
+import { useState, useEffect } from "react";
+import {
+  ChevronUpIcon,
+  ChevronDownIcon,
+} from "@/assets/svg/icons";
+import useCommonStore from "@/stores/common/CommonStore";
 import {
   StyledSelect,
   Selected,
@@ -7,30 +11,72 @@ import {
   Options,
   Option,
 } from "./Select.style";
+import { useNavigate } from "react-router-dom";
 
-const Select = ({ options, selectedValue, setSelectedValue, width }) => {
-  const [isShowOptions, setIsShowOptions] = useState(false);
+const Select = ({
+  options,
+  selectedValue,
+  setSelectedValue,
+  width,
+  link,
+}) => {
+  const [isShowOptions, setIsShowOptions] =
+    useState(false);
+  const [
+    pendingNavigation,
+    setPendingNavigation,
+  ] = useState(false);
+  const { setCriteria } = useCommonStore();
+  const navigate = useNavigate();
+
   const handleClickOptions = () => {
     setIsShowOptions(!isShowOptions);
   };
+
   const handleOptionClick = (option) => {
     setSelectedValue(option);
+    setCriteria(option);
     setIsShowOptions(false);
+    setPendingNavigation(true);
   };
+  useEffect(() => {
+    if (pendingNavigation) {
+      navigate(link);
+      setPendingNavigation(false);
+    }
+  }, [pendingNavigation, navigate, link]);
   return (
     <StyledSelect style={{ width }}>
       <Selected onClick={handleClickOptions}>
-        <SelectedValue>{selectedValue}</SelectedValue>
+        <SelectedValue>
+          {selectedValue}
+        </SelectedValue>
         {isShowOptions ? (
-          <ChevronUpIcon width="16" height="12" class="bi bi-chevron-up" />
+          <ChevronUpIcon
+            width="16"
+            height="12"
+            class="bi bi-chevron-up"
+          />
         ) : (
-          <ChevronDownIcon width="16" height="12" class="bi bi-chevron-down" />
+          <ChevronDownIcon
+            width="16"
+            height="12"
+            class="bi bi-chevron-down"
+          />
         )}
       </Selected>
       {}
-      <Options active={isShowOptions} style={{ width }}>
+      <Options
+        active={isShowOptions}
+        style={{ width }}
+      >
         {options.map((option, index) => (
-          <Option key={index} onClick={() => handleOptionClick(option)}>
+          <Option
+            key={index}
+            onClick={() =>
+              handleOptionClick(option)
+            }
+          >
             {option}
           </Option>
         ))}

--- a/src/components/community/NavBar/NavBar.jsx
+++ b/src/components/community/NavBar/NavBar.jsx
@@ -1,12 +1,20 @@
 import { Navigate } from "./NavBar.style";
 import Button from "@components/common/button/Button";
 import { PATH } from "@router/Constants";
-import { Link, useLocation } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+} from "react-router-dom";
 const NavBar = () => {
   const location = useLocation();
   return (
     <Navigate>
-      <Link to={PATH.COMMUNITY("Q&A")}>
+      <Link
+        to={
+          PATH.COMMUNITY("Q&A") +
+          "?keyword=&criteria=date&pageNo=1"
+        }
+      >
         {location.pathname.includes("Q&A") ? (
           <Button text bold>
             🙋 Q&A
@@ -15,7 +23,12 @@ const NavBar = () => {
           <Button text> 🙋 Q&A</Button>
         )}
       </Link>
-      <Link to={PATH.COMMUNITY("concern")}>
+      <Link
+        to={
+          PATH.COMMUNITY("concern") +
+          "?keyword=&criteria=date&pageNo=1"
+        }
+      >
         {location.pathname.includes("concern") ? (
           <Button text bold>
             🤔 고민

--- a/src/components/community/communityBoard/CommunityBoardPage.jsx
+++ b/src/components/community/communityBoard/CommunityBoardPage.jsx
@@ -1,18 +1,13 @@
 import { Link } from "react-router-dom";
 import { PATH } from "@router/Constants";
 import NoticeCard from "@components/community/Card/NoticeCard";
-import { NOTICE_LIST } from "@dummy/Notice";
-import { QNA_LIST } from "@dummy/Qna";
 import CommunityCard from "@components/community/Card/CommunityCard";
-import { CONCERN_LIST } from "@dummy/Concern";
 import { StyledButton } from "@pages/Community/CommunityPage.style";
 import { useEffect, useState } from "react";
 import useNoticeStore from "@/stores/Community/NoticeStore";
 import useQnaStore from "@/stores/Community/QnaStore";
 import useConcernStore from "@/stores/Community/ConcernStore";
-const CONCERNS = CONCERN_LIST;
-const notices = NOTICE_LIST;
-const qnas = QNA_LIST;
+
 const CommunityBoardPage = ({ type }) => {
   const [boardList, setBoardList] = useState([]);
   const { noticeList, fetchNoticeList } =
@@ -25,10 +20,10 @@ const CommunityBoardPage = ({ type }) => {
   }, [noticeList]);
   useEffect(() => {
     if (type === "Q&A") {
-      fetchQnaList("");
+      fetchQnaList("", "", 1);
       setBoardList(qnaList);
     } else {
-      fetchConcernList("");
+      fetchConcernList("", "", 1);
       setBoardList(concernList);
     }
   }, [type]);
@@ -40,9 +35,6 @@ const CommunityBoardPage = ({ type }) => {
           key={notice.id}
         />
       ))}
-      {/* <NoticeCard notice={notices[0]} />
-      <NoticeCard notice={notices[1]} />
-      <NoticeCard notice={notices[2]} /> */}
       <br />
       {boardList.map((board) => (
         <CommunityCard

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -40,7 +40,12 @@ const Header = () => {
           <Link to={PATH.COURSES}>
             <Button text>강의</Button>
           </Link>
-          <Link to={PATH.COMMUNITY("concern")}>
+          <Link
+            to={
+              PATH.COMMUNITY("concern") +
+              "?keyword=&criteria=date&pageNo=1"
+            }
+          >
             <Button text>커뮤니티</Button>
           </Link>
         </Flex>

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -43,7 +43,7 @@ const Header = () => {
           <Link
             to={
               PATH.COMMUNITY("concern") +
-              "?keyword=&criteria=date&pageNo=1"
+              "?keyword=&criteria=최신순&pageNo=1"
             }
           >
             <Button text>커뮤니티</Button>

--- a/src/pages/Community/CommunityPage.jsx
+++ b/src/pages/Community/CommunityPage.jsx
@@ -4,24 +4,42 @@ import Pagination from "@components/common/pagination/Pagination";
 import {
   Container,
   ContentContainer,
-  StyledButton,
 } from "./CommunityPage.style";
 import { useLocation } from "react-router-dom";
 import CommunityBoardPage from "@components/community/communityBoard/CommunityBoardPage";
+import { PATH } from "@router/Constants";
+import useCommonStore from "@/stores/common/CommonStore";
 const CommunityPage = () => {
+  const { keyword, setKeyword } =
+    useCommonStore();
   const location = useLocation();
   const type = location.pathname.split("/")[2];
+  const params = new URLSearchParams(
+    location.search
+  );
+  const pageNo = parseInt(params.get("pageNo"));
+  console.log(pageNo);
   return (
     <Container>
       <NavBar />
       <ContentContainer>
-        <SearchBar />
+        <SearchBar
+          link={
+            PATH.COMMUNITY(type) +
+            `?keyword=${keyword}&criteria=date&pageNo=${pageNo}`
+          }
+        />
         <CommunityBoardPage type={type} />
         <Pagination
           totalItems={51}
           itemCountPerPage={5}
           pageCount={5}
-          currentPage={1}
+          currentPage={pageNo}
+          type={type}
+          link={
+            PATH.COMMUNITY(type) +
+            `?keyword=${keyword}&criteria=date`
+          }
         />
       </ContentContainer>
     </Container>

--- a/src/pages/Community/CommunityPage.jsx
+++ b/src/pages/Community/CommunityPage.jsx
@@ -1,6 +1,6 @@
 import SearchBar from "@components/common/searchbar/SearchBar";
 import NavBar from "@components/community/NavBar/NavBar";
-
+import Pagination from "@components/common/pagination/Pagination";
 import {
   Container,
   ContentContainer,
@@ -17,6 +17,12 @@ const CommunityPage = () => {
       <ContentContainer>
         <SearchBar />
         <CommunityBoardPage type={type} />
+        <Pagination
+          totalItems={51}
+          itemCountPerPage={5}
+          pageCount={5}
+          currentPage={1}
+        />
       </ContentContainer>
     </Container>
   );

--- a/src/pages/Community/CommunityPage.jsx
+++ b/src/pages/Community/CommunityPage.jsx
@@ -10,8 +10,7 @@ import CommunityBoardPage from "@components/community/communityBoard/CommunityBo
 import { PATH } from "@router/Constants";
 import useCommonStore from "@/stores/common/CommonStore";
 const CommunityPage = () => {
-  const { keyword, setKeyword } =
-    useCommonStore();
+  const { keyword, criteria } = useCommonStore();
   const location = useLocation();
   const type = location.pathname.split("/")[2];
   const params = new URLSearchParams(
@@ -26,7 +25,7 @@ const CommunityPage = () => {
         <SearchBar
           link={
             PATH.COMMUNITY(type) +
-            `?keyword=${keyword}&criteria=date&pageNo=${pageNo}`
+            `?keyword=${keyword}&criteria=${criteria}&pageNo=1`
           }
         />
         <CommunityBoardPage type={type} />
@@ -38,7 +37,7 @@ const CommunityPage = () => {
           type={type}
           link={
             PATH.COMMUNITY(type) +
-            `?keyword=${keyword}&criteria=date`
+            `?keyword=${keyword}&criteria=${criteria}`
           }
         />
       </ContentContainer>

--- a/src/stores/Community/ConcernStore.js
+++ b/src/stores/Community/ConcernStore.js
@@ -17,10 +17,16 @@ const useConcernStore = create((set) => ({
   scrappedConcerns: [],
 
   //고민 목록 가져오기
-  fetchConcernList: async (keyword) => {
+  fetchConcernList: async (
+    keyword,
+    criteria,
+    pageNo
+  ) => {
     try {
       const response = await getConcernList(
-        keyword
+        keyword,
+        criteria,
+        pageNo
       );
       set({ concernList: response.data });
     } catch (e) {

--- a/src/stores/Community/QnaStore.js
+++ b/src/stores/Community/QnaStore.js
@@ -17,10 +17,16 @@ const useQnaStore = create((set, get) => ({
   scrappedQnas: [],
 
   //질문 목록 가져오기
-  fetchQnaList: async (keyword) => {
+  fetchQnaList: async (
+    keyword,
+    criteria,
+    pageNo
+  ) => {
     try {
       const response = await getQuestionList(
-        keyword
+        keyword,
+        criteria,
+        pageNo
       );
       set({ qnaList: response.data });
     } catch (e) {

--- a/src/stores/common/CommonStore.js
+++ b/src/stores/common/CommonStore.js
@@ -1,0 +1,9 @@
+import { create } from "zustand";
+const useCommonStore = create((set) => ({
+  keyword: "",
+  criteria: "",
+  setKeyword: (word) => set({ keyword: word }),
+  setCriteria: (condition) =>
+    set({ criteria: condition }),
+}));
+export default useCommonStore;


### PR DESCRIPTION
### #️⃣연관된 이슈

- resolve #51 

### 📝상세 내용

- components -> common -> pagination -> Pagination생성
- prop으로 totalItems, itemCountPerPage, pageCount, currentPage, link를 받음
- link를 설정해줘야 페이지 버튼 클릭시 해당 링크로 이동
- header.jsx에서 커뮤니티버튼 클릭 시 url에 쿼리스트링 추가
- useCommonStore만들어서 keyword  & criteria 상태관리
- searchbar에서 prop에 link추가해서 검색 구현
- select에서 prop에 link추가해서 조건 선택 시 검색 구현 
