### PR TITLE
REFACTOR : 커뮤니티 리스트 & 커뮤니티 상세보기 수정

### DIFF
--- a/src/apis/community/QnaApi.js
+++ b/src/apis/community/QnaApi.js
@@ -9,7 +9,7 @@ export const getQuestionList = async (
   return await axiosInstance.get(
     END_POINT.COMMUNITY_QUESTION,
     {
-      params: { keyword, criteria, page },
+      params: { page, criteria, keyword },
     }
   );
 };

--- a/src/components/community/Card/CommunityCard.jsx
+++ b/src/components/community/Card/CommunityCard.jsx
@@ -22,13 +22,20 @@ import useConcernStore from "@stores/Community/ConcernStore";
 const CommunityCard = ({ board, type }) => {
   const navigate = useNavigate();
   const handleClickConcernCard = () => {
-    navigate(PATH.COMMUNITY_DETAIL(type, initialBoard.articleId));
+    navigate(
+      PATH.COMMUNITY_DETAIL(
+        type,
+        initialBoard.articleId
+      )
+    );
   };
   const { likeQna, scrapQna } = useQnaStore();
-  const { likeConcern, scrapConcern } = useConcernStore();
-  const [initialBoard, setInitialBoard] = useState(board);
+  const { likeConcern, scrapConcern } =
+    useConcernStore();
+  const [initialBoard, setInitialBoard] =
+    useState(board);
   const handleClickLike = () => {
-    if (type === "Q&A") {
+    if (type === "QNA") {
       likeQna(initialBoard.articleId);
     } else {
       likeConcern(initialBoard.articleId);
@@ -42,7 +49,7 @@ const CommunityCard = ({ board, type }) => {
     }));
   };
   const handleClickBookMark = () => {
-    if (type === "Q&A") {
+    if (type === "QNA") {
       scrapQna(initialBoard.articleId);
     } else {
       scrapConcern(initialBoard.articleId);
@@ -59,7 +66,9 @@ const CommunityCard = ({ board, type }) => {
     <CardContainer>
       <TitleContainer>
         <Pointer>
-          <Title onClick={handleClickConcernCard}>{board.title}</Title>
+          <Title onClick={handleClickConcernCard}>
+            {board.title}
+          </Title>
         </Pointer>
         <Pointer>
           {initialBoard.isScrapped ? (
@@ -81,9 +90,15 @@ const CommunityCard = ({ board, type }) => {
       <Content>{initialBoard.content}</Content>
       <InfoContainer>
         <ContentContainer>
-          <Content>{initialBoard.memberId}</Content>
+          <Content>
+            {initialBoard.memberId}
+          </Content>
           <Content>3분전</Content>
-          {type === "Q&A" && <Content>{initialBoard.lectureTitle}</Content>}
+          {type === "QNA" && (
+            <Content>
+              {initialBoard.lectureTitle}
+            </Content>
+          )}
         </ContentContainer>
         <ContentContainer>
           <Content>
@@ -101,7 +116,11 @@ const CommunityCard = ({ board, type }) => {
                   onClick={handleClickLike}
                 />
               ) : (
-                <LikeIcon width="16" height="16" onClick={handleClickLike} />
+                <LikeIcon
+                  width="16"
+                  height="16"
+                  onClick={handleClickLike}
+                />
               )}
               {initialBoard.likeCount}
             </Pointer>

--- a/src/components/community/Card/CommunityCard.jsx
+++ b/src/components/community/Card/CommunityCard.jsx
@@ -24,8 +24,8 @@ const CommunityCard = ({ board, type }) => {
   const handleClickConcernCard = () => {
     navigate(
       PATH.COMMUNITY_DETAIL(
-        type,
-        initialBoard.articleId
+        type === "QNA" ? "Q&A" : "concern",
+        board.articleId
       )
     );
   };

--- a/src/components/community/Card/CommunityCard.jsx
+++ b/src/components/community/Card/CommunityCard.jsx
@@ -21,19 +21,24 @@ import useQnaStore from "@stores/Community/QnaStore";
 import useConcernStore from "@stores/Community/ConcernStore";
 const CommunityCard = ({ board, type }) => {
   const navigate = useNavigate();
+  const [initialBoard, setInitialBoard] =
+    useState(board);
   const handleClickConcernCard = () => {
     navigate(
       PATH.COMMUNITY_DETAIL(
         type === "QNA" ? "Q&A" : "concern",
         board.articleId
-      )
+      ),
+      {
+        state: {
+          board: initialBoard,
+        },
+      }
     );
   };
   const { likeQna, scrapQna } = useQnaStore();
   const { likeConcern, scrapConcern } =
     useConcernStore();
-  const [initialBoard, setInitialBoard] =
-    useState(board);
   const handleClickLike = () => {
     if (type === "QNA") {
       likeQna(initialBoard.articleId);

--- a/src/components/community/Card/NoticeCard.jsx
+++ b/src/components/community/Card/NoticeCard.jsx
@@ -5,7 +5,10 @@ import {
   Content,
   Pointer,
 } from "./NoticeCard.style.js";
-import { VisibleIcon, LikeIcon } from "@assets/svg/icons";
+import {
+  VisibleIcon,
+  LikeIcon,
+} from "@assets/svg/icons";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PATH } from "@router/Constants";
@@ -14,27 +17,44 @@ import useNoticeStore from "@stores/Community/NoticeStore";
 const Notice = ({ notice }) => {
   const navigate = useNavigate();
   const { likeNotice } = useNoticeStore();
+  const [initialNotice, setInitialNotice] =
+    useState(notice);
   const handleClickConcernCard = () => {
-    navigate(PATH.COMMUNITY_DETAIL("notice", initialNotice.articleId));
+    navigate(
+      PATH.COMMUNITY_DETAIL(
+        "notice",
+        initialNotice.articleId
+      ),
+      {
+        state: {
+          board: initialNotice,
+        },
+      }
+    );
   };
-  const [initialNotice, setInitialNotice] = useState(notice);
   const handleClickLike = () => {
     likeNotice(initialNotice.articleId);
     setInitialNotice((prevNotice) => ({
       ...prevNotice,
       isLike: !prevNotice.isLiked,
-      likeCount: prevNotice.isLiked ? prevNotice.like - 1 : prevNotice.like + 1,
+      likeCount: prevNotice.isLiked
+        ? prevNotice.like - 1
+        : prevNotice.like + 1,
     }));
   };
   return (
     <NoticeContainer>
       <Pointer>
-        <NoticeTitle onClick={handleClickConcernCard}>
+        <NoticeTitle
+          onClick={handleClickConcernCard}
+        >
           {initialNotice.title}
         </NoticeTitle>
       </Pointer>
       <ContentContainer>
-        <Content>{initialNotice.createTime}</Content>
+        <Content>
+          {initialNotice.createTime}
+        </Content>
         <Content>
           <Pointer>
             {initialNotice.isLiked ? (
@@ -46,7 +66,11 @@ const Notice = ({ notice }) => {
                 onClick={handleClickLike}
               />
             ) : (
-              <LikeIcon width="16" height="16" onClick={handleClickLike} />
+              <LikeIcon
+                width="16"
+                height="16"
+                onClick={handleClickLike}
+              />
             )}
             {initialNotice.likeCount}
           </Pointer>

--- a/src/components/community/communityBoard/CommunityBoardPage.jsx
+++ b/src/components/community/communityBoard/CommunityBoardPage.jsx
@@ -8,7 +8,7 @@ import useNoticeStore from "@stores/Community/NoticeStore";
 import useQnaStore from "@stores/Community/QnaStore";
 import useConcernStore from "@stores/Community/ConcernStore";
 
-const CommunityBoardPage = ({ type }) => {
+const CommunityBoardPage = ({ type, pageNo }) => {
   const [boardList, setBoardList] = useState([]);
   const { noticeList, fetchNoticeList } =
     useNoticeStore();
@@ -20,10 +20,10 @@ const CommunityBoardPage = ({ type }) => {
   }, []);
   useEffect(() => {
     if (type === "Q&A") {
-      fetchQnaList("", "", 0);
+      fetchQnaList("", "", pageNo - 1);
       setBoardList(qnaList);
     } else {
-      fetchConcernList("", "", 0);
+      fetchConcernList("", "", pageNo - 1);
       setBoardList(concernList);
     }
   }, [type, boardList, qnaList, concernList]);

--- a/src/components/community/communityBoard/CommunityBoardPage.jsx
+++ b/src/components/community/communityBoard/CommunityBoardPage.jsx
@@ -10,9 +10,11 @@ import useConcernStore from "@stores/Community/ConcernStore";
 
 const CommunityBoardPage = ({ type }) => {
   const [boardList, setBoardList] = useState([]);
-  const { noticeList, fetchNoticeList } = useNoticeStore();
+  const { noticeList, fetchNoticeList } =
+    useNoticeStore();
   const { qnaList, fetchQnaList } = useQnaStore();
-  const { concernList, fetchConcernList } = useConcernStore();
+  const { concernList, fetchConcernList } =
+    useConcernStore();
   useEffect(() => {
     fetchNoticeList();
   }, []);
@@ -24,15 +26,22 @@ const CommunityBoardPage = ({ type }) => {
       fetchConcernList("", "", 0);
       setBoardList(concernList);
     }
-  }, [type]);
+  }, [type, boardList, qnaList, concernList]);
   return (
     <>
       {noticeList.map((notice) => (
-        <NoticeCard notice={notice} key={notice.articleId} />
+        <NoticeCard
+          notice={notice}
+          key={notice.articleId}
+        />
       ))}
       <br />
-      {concernList.map((board) => (
-        <CommunityCard board={board} key={board.articleId} type={type} />
+      {boardList.map((board) => (
+        <CommunityCard
+          board={board}
+          key={board.articleId}
+          type={board.boardType}
+        />
       ))}
       <Link
         to={PATH.COMMUNITY_REGIST(type)}
@@ -44,7 +53,10 @@ const CommunityBoardPage = ({ type }) => {
         }}
       >
         <StyledButton fill bold>
-          ✍️ {type === "Q&A" ? "질문하기" : "고민 나누기"}
+          ✍️{" "}
+          {type === "Q&A"
+            ? "질문하기"
+            : "고민 나누기"}
         </StyledButton>
       </Link>
     </>

--- a/src/components/community/communityBoard/CommunityBoardPage.jsx
+++ b/src/components/community/communityBoard/CommunityBoardPage.jsx
@@ -26,7 +26,13 @@ const CommunityBoardPage = ({ type, pageNo }) => {
       fetchConcernList("", "", pageNo - 1);
       setBoardList(concernList);
     }
-  }, [type, boardList, qnaList, concernList]);
+  }, [
+    type,
+    boardList,
+    qnaList,
+    concernList,
+    pageNo,
+  ]);
   return (
     <>
       {noticeList.map((notice) => (

--- a/src/components/community/communityBoard/CommunityBoardPage.jsx
+++ b/src/components/community/communityBoard/CommunityBoardPage.jsx
@@ -8,31 +8,16 @@ import useNoticeStore from "@stores/Community/NoticeStore";
 import useQnaStore from "@stores/Community/QnaStore";
 import useConcernStore from "@stores/Community/ConcernStore";
 
-const CommunityBoardPage = ({ type, pageNo }) => {
-  const [boardList, setBoardList] = useState([]);
+const CommunityBoardPage = ({
+  type,
+  initialBoardList,
+}) => {
   const { noticeList, fetchNoticeList } =
     useNoticeStore();
-  const { qnaList, fetchQnaList } = useQnaStore();
-  const { concernList, fetchConcernList } =
-    useConcernStore();
+
   useEffect(() => {
     fetchNoticeList();
   }, []);
-  useEffect(() => {
-    if (type === "Q&A") {
-      fetchQnaList("", "", pageNo - 1);
-      setBoardList(qnaList);
-    } else {
-      fetchConcernList("", "", pageNo - 1);
-      setBoardList(concernList);
-    }
-  }, [
-    type,
-    boardList,
-    qnaList,
-    concernList,
-    pageNo,
-  ]);
   return (
     <>
       {noticeList.map((notice) => (
@@ -42,13 +27,14 @@ const CommunityBoardPage = ({ type, pageNo }) => {
         />
       ))}
       <br />
-      {boardList.map((board) => (
-        <CommunityCard
-          board={board}
-          key={board.articleId}
-          type={board.boardType}
-        />
-      ))}
+      {initialBoardList &&
+        initialBoardList.map((board) => (
+          <CommunityCard
+            board={board}
+            key={board.articleId}
+            type={board.boardType}
+          />
+        ))}
       <Link
         to={PATH.COMMUNITY_REGIST(type)}
         state={{ type }}

--- a/src/pages/Service/Community/CommunityPage.jsx
+++ b/src/pages/Service/Community/CommunityPage.jsx
@@ -15,21 +15,27 @@ import useQnaStore from "@stores/Community/QnaStore";
 const CommunityPage = () => {
   const { keyword, criteria } = useCommonStore();
   const location = useLocation();
-  const [type, setType] = useState(
-    location.pathname.split("/")[2]
-  );
+  const type = location.pathname.split("/")[2];
   const params = new URLSearchParams(
     location.search
   );
-  const { qnaList } = useQnaStore();
-  const { concernList } = useConcernStore();
   const [pageNo, setPageNo] = useState(
     parseInt(params.get("pageNo"))
   );
+  const { qnaList, fetchQnaList } = useQnaStore();
+  const { concernList, fetchConcernList } =
+    useConcernStore();
   useEffect(() => {
-    setType(location.pathname.split("/")[2]);
-    setPageNo(parseInt(params.get("pageNo")));
-  }, [location.pathname]);
+    if (type === "Q&A") {
+      fetchQnaList(keyword, criteria, pageNo - 1);
+    } else {
+      fetchConcernList(
+        keyword,
+        criteria,
+        pageNo - 1
+      );
+    }
+  }, [type]);
   return (
     <Container>
       <NavBar />
@@ -43,12 +49,17 @@ const CommunityPage = () => {
         <CommunityBoardPage
           type={type}
           pageNo={pageNo}
+          initialBoardList={
+            type === "Q&A"
+              ? qnaList.data
+              : concernList.data
+          }
         />
         <Pagination
           totalItems={
             type === "Q&A"
-              ? qnaList.length
-              : concernList.length
+              ? qnaList.totalCount
+              : concernList.totalCount
           }
           itemCountPerPage={10}
           pageCount={5}

--- a/src/pages/Service/Community/CommunityPage.jsx
+++ b/src/pages/Service/Community/CommunityPage.jsx
@@ -1,18 +1,28 @@
 import SearchBar from "@components/common/searchbar/SearchBar";
 import NavBar from "@components/community/NavBar/NavBar";
 import Pagination from "@components/common/pagination/Pagination";
-import { Container, ContentContainer } from "./CommunityPage.style";
+import {
+  Container,
+  ContentContainer,
+} from "./CommunityPage.style";
 import { useLocation } from "react-router-dom";
 import CommunityBoardPage from "@components/community/communityBoard/CommunityBoardPage";
 import { PATH } from "@router/Constants";
 import useCommonStore from "@stores/common/CommonStore";
+import { useState, useEffect } from "react";
 const CommunityPage = () => {
   const { keyword, criteria } = useCommonStore();
   const location = useLocation();
-  const type = location.pathname.split("/")[2];
-  const params = new URLSearchParams(location.search);
+  const [type, setType] = useState(
+    location.pathname.split("/")[2]
+  );
+  const params = new URLSearchParams(
+    location.search
+  );
   const pageNo = parseInt(params.get("pageNo"));
-  console.log(pageNo);
+  useEffect(() => {
+    setType(location.pathname.split("/")[2]);
+  }, [location.pathname]);
   return (
     <Container>
       <NavBar />
@@ -31,7 +41,8 @@ const CommunityPage = () => {
           currentPage={pageNo}
           type={type}
           link={
-            PATH.COMMUNITY(type) + `?keyword=${keyword}&criteria=${criteria}`
+            PATH.COMMUNITY(type) +
+            `?keyword=${keyword}&criteria=${criteria}`
           }
         />
       </ContentContainer>

--- a/src/pages/Service/Community/CommunityPage.jsx
+++ b/src/pages/Service/Community/CommunityPage.jsx
@@ -10,6 +10,8 @@ import CommunityBoardPage from "@components/community/communityBoard/CommunityBo
 import { PATH } from "@router/Constants";
 import useCommonStore from "@stores/common/CommonStore";
 import { useState, useEffect } from "react";
+import useConcernStore from "@stores/Community/ConcernStore";
+import useQnaStore from "@stores/Community/QnaStore";
 const CommunityPage = () => {
   const { keyword, criteria } = useCommonStore();
   const location = useLocation();
@@ -19,9 +21,14 @@ const CommunityPage = () => {
   const params = new URLSearchParams(
     location.search
   );
-  const pageNo = parseInt(params.get("pageNo"));
+  const { qnaList } = useQnaStore();
+  const { concernList } = useConcernStore();
+  const [pageNo, setPageNo] = useState(
+    parseInt(params.get("pageNo"))
+  );
   useEffect(() => {
     setType(location.pathname.split("/")[2]);
+    setPageNo(parseInt(params.get("pageNo")));
   }, [location.pathname]);
   return (
     <Container>
@@ -33,10 +40,17 @@ const CommunityPage = () => {
             `?keyword=${keyword}&criteria=${criteria}&pageNo=1`
           }
         />
-        <CommunityBoardPage type={type} />
+        <CommunityBoardPage
+          type={type}
+          pageNo={pageNo}
+        />
         <Pagination
-          totalItems={51}
-          itemCountPerPage={5}
+          totalItems={
+            type === "Q&A"
+              ? qnaList.length
+              : concernList.length
+          }
+          itemCountPerPage={10}
           pageCount={5}
           currentPage={pageNo}
           type={type}

--- a/src/pages/Service/CommunityDetail/CommunityDetail.jsx
+++ b/src/pages/Service/CommunityDetail/CommunityDetail.jsx
@@ -38,50 +38,68 @@ const CommunityDetail = () => {
   const splitPath = location.pathname.split("/");
   const type = splitPath[2];
   const boardId = splitPath[3];
-  const [board, setBoard] = useState({});
-  const { notice, fetchNoticeDetail, likeNotice, scrapNotice } =
-    useNoticeStore();
-  const { concern, fetchConcernDetail, likeConcern, scrapConcern } =
-    useConcernStore();
-  const { qna, fetchQnaDetail, likeQna, scrapQna } = useQnaStore();
+  const [board, setBoard] = useState(null);
+  const {
+    notice,
+    fetchNoticeDetail,
+    likeNotice,
+    scrapNotice,
+  } = useNoticeStore();
+  const {
+    concern,
+    fetchConcernDetail,
+    likeConcern,
+    scrapConcern,
+  } = useConcernStore();
+  const {
+    qna,
+    fetchQnaDetail,
+    likeQna,
+    scrapQna,
+  } = useQnaStore();
   useEffect(() => {
     const fetchData = async () => {
+      let fetchBoard;
       if (type === "notice") {
         await fetchNoticeDetail(boardId);
-        setBoard(notice);
+        fetchBoard = notice;
       } else if (type === "concern") {
         await fetchConcernDetail(boardId);
-        setBoard(concern);
+        fetchBoard = concern;
       } else {
         await fetchQnaDetail(boardId);
-        setBoard(qna);
+        fetchBoard = qna;
       }
+      setBoard(fetchBoard);
     };
     fetchData();
-  }, [type, boardId, notice, concern, qna]);
-
-  const [viewReview, setViewReview] = useState(false);
-  const [writeReview, setWriteReview] = useState(false);
-  const [isMeetballClick, setIsMeetballClick] = useState(false);
+  }, [board]);
+  console.log(board);
+  const [viewReview, setViewReview] =
+    useState(false);
+  const [writeReview, setWriteReview] =
+    useState(false);
+  const [isMeetballClick, setIsMeetballClick] =
+    useState(false);
   const handleClickViewReview = () => {
     setViewReview(!viewReview);
   };
-  const handleClickLike = (articleId) => {
+  const handleClickLike = () => {
     if (type === "notice") {
-      likeNotice(articleId);
+      likeNotice(boardId);
     } else if (type === "qna") {
-      likeQna(articleId);
+      likeQna(boardId);
     } else {
-      likeConcern(articleId);
+      likeConcern(boardId);
     }
   };
-  const handleClickBookMark = (articleId) => {
+  const handleClickBookMark = () => {
     if (type === "notice") {
-      scrapNotice(articleId);
+      scrapNotice(boardId);
     } else if (type === "qna") {
-      scrapQna(articleId);
+      scrapQna(boardId);
     } else {
-      scrapConcern(articleId);
+      scrapConcern(boardId);
     }
   };
   const handleClickGoWriteReview = () => {
@@ -91,6 +109,9 @@ const CommunityDetail = () => {
     console.log(isMeetballClick);
     setIsMeetballClick(!isMeetballClick);
   };
+  if (!board) {
+    return <div>Loading...</div>;
+  }
   return (
     <DetailBlock>
       <Container>
@@ -124,11 +145,18 @@ const CommunityDetail = () => {
                   onClick={handleClickLike}
                 />
               ) : (
-                <LikeIcon width="16" height="16" onClick={handleClickLike} />
+                <LikeIcon
+                  width="16"
+                  height="16"
+                  onClick={handleClickLike}
+                />
               )}
               <Content>0</Content>
             </ContainerCol>
-            <ContainerCol type="icon" style={{ position: "relative" }}>
+            <ContainerCol
+              type="icon"
+              style={{ position: "relative" }}
+            >
               <MeetballIcon
                 width="16"
                 height="16"
@@ -137,7 +165,9 @@ const CommunityDetail = () => {
               <br />
               {isMeetballClick && (
                 <MeetballSelect
-                  path={PATH.COMMUNITY_UPDATE(board.ariticleId)}
+                  path={PATH.COMMUNITY_UPDATE(
+                    board.ariticleId
+                  )}
                 />
               )}
             </ContainerCol>
@@ -149,33 +179,54 @@ const CommunityDetail = () => {
         </ContainerRow>
         <Content>{board.createTime} 작성</Content>
         <ContentContainer>
-          <Content type="black">{board.content}</Content>
+          <Content type="black">
+            {board.content}
+          </Content>
           {type === "qna" && (
             <ContainerRow type="center">
               <QnaImg />
               <ContainerCol>
-                <CourseName>{board.lectureTitle}</CourseName>
-                <Content>{board.courseTitle}</Content>
+                <CourseName>
+                  {board.lectureTitle}
+                </CourseName>
+                <Content>
+                  {board.courseTitle}
+                </Content>
               </ContainerCol>
             </ContainerRow>
           )}
           <ContainerRow>
-            <Button text onClick={handleClickViewReview}>
+            <Button
+              text
+              onClick={handleClickViewReview}
+            >
               {!viewReview ? (
-                <ChevronDownIcon width="16" height="16" />
+                <ChevronDownIcon
+                  width="16"
+                  height="16"
+                />
               ) : (
-                <ChevronUpIcon width="16" height="16" />
+                <ChevronUpIcon
+                  width="16"
+                  height="16"
+                />
               )}{" "}
               {board.commentCount}개 댓글 보기
             </Button>
-            <Button text onClick={handleClickGoWriteReview}>
-              <ChatIcon width="16" height="16" /> 댓글 작성하기
+            <Button
+              text
+              onClick={handleClickGoWriteReview}
+            >
+              <ChatIcon width="16" height="16" />{" "}
+              댓글 작성하기
             </Button>
           </ContainerRow>
         </ContentContainer>
         {writeReview && <RegistReview />}
         {viewReview &&
-          board.comments.map((review) => <Review content={review.content} />)}
+          board.comments.map((review) => (
+            <Review content={review.content} />
+          ))}
       </Container>
     </DetailBlock>
   );

--- a/src/pages/Service/CommunityDetail/CommunityDetail.jsx
+++ b/src/pages/Service/CommunityDetail/CommunityDetail.jsx
@@ -73,7 +73,7 @@ const CommunityDetail = () => {
       setBoard(fetchBoard);
     };
     fetchData();
-  }, [board]);
+  }, []);
   console.log(board);
   const [viewReview, setViewReview] =
     useState(false);

--- a/src/pages/Service/CommunityDetail/CommunityDetail.jsx
+++ b/src/pages/Service/CommunityDetail/CommunityDetail.jsx
@@ -35,10 +35,12 @@ import useNoticeStore from "@stores/Community/NoticeStore";
 import useConcernStore from "@stores/Community/ConcernStore";
 const CommunityDetail = () => {
   const location = useLocation();
+  const { state } = useLocation();
   const splitPath = location.pathname.split("/");
   const type = splitPath[2];
-  const boardId = splitPath[3];
-  const [board, setBoard] = useState(null);
+  const { board } = state;
+  const [initialBoard, setInitialBoard] =
+    useState(board);
   const {
     notice,
     fetchNoticeDetail,
@@ -57,24 +59,7 @@ const CommunityDetail = () => {
     likeQna,
     scrapQna,
   } = useQnaStore();
-  useEffect(() => {
-    const fetchData = async () => {
-      let fetchBoard;
-      if (type === "notice") {
-        await fetchNoticeDetail(boardId);
-        fetchBoard = notice;
-      } else if (type === "concern") {
-        await fetchConcernDetail(boardId);
-        fetchBoard = concern;
-      } else {
-        await fetchQnaDetail(boardId);
-        fetchBoard = qna;
-      }
-      setBoard(fetchBoard);
-    };
-    fetchData();
-  }, []);
-  console.log(board);
+
   const [viewReview, setViewReview] =
     useState(false);
   const [writeReview, setWriteReview] =
@@ -86,21 +71,35 @@ const CommunityDetail = () => {
   };
   const handleClickLike = () => {
     if (type === "notice") {
-      likeNotice(boardId);
+      likeNotice(initialBoard.articleId);
     } else if (type === "qna") {
-      likeQna(boardId);
+      likeQna(initialBoard.articleId);
     } else {
-      likeConcern(boardId);
+      likeConcern(initialBoard.articleId);
     }
+    setInitialBoard((prevBoard) => ({
+      ...prevBoard,
+      isLiked: !prevBoard.isLiked,
+      likeCount: prevBoard.isLiked
+        ? prevBoard.likeCount - 1
+        : prevBoard.likeCount + 1,
+    }));
   };
   const handleClickBookMark = () => {
     if (type === "notice") {
-      scrapNotice(boardId);
+      scrapNotice(initialBoard.articleId);
     } else if (type === "qna") {
-      scrapQna(boardId);
+      scrapQna(initialBoard.articleId);
     } else {
-      scrapConcern(boardId);
+      scrapConcern(initialBoard.articleId);
     }
+    setInitialBoard((prevBoard) => ({
+      ...prevBoard,
+      isScrapped: !prevBoard.isScrapped,
+      scrapCount: prevBoard.isScrapped
+        ? prevBoard.scrapCount - 1
+        : prevBoard.scrapCount + 1,
+    }));
   };
   const handleClickGoWriteReview = () => {
     setWriteReview(!writeReview);
@@ -109,125 +108,140 @@ const CommunityDetail = () => {
     console.log(isMeetballClick);
     setIsMeetballClick(!isMeetballClick);
   };
-  if (!board) {
-    return <div>Loading...</div>;
-  }
   return (
     <DetailBlock>
-      <Container>
-        <TitleContainer>
-          <Title>{board.title}</Title>
-          <ContainerRow>
-            <ContainerCol type="icon">
-              {board.isScrapped ? (
-                <BookMarkIcon
-                  width="16"
-                  height="16"
-                  fill={color.yellow}
-                  onClick={handleClickBookMark}
-                />
-              ) : (
-                <BookMarkIcon
-                  width="16"
-                  height="16"
-                  onClick={handleClickBookMark}
-                />
-              )}
-              <Content>0</Content>
-            </ContainerCol>
-            <ContainerCol type="icon">
-              {board.iLiked ? (
-                <LikeIcon
-                  fill={color.pinkRed}
-                  stroke="none"
-                  width="16"
-                  height="16"
-                  onClick={handleClickLike}
-                />
-              ) : (
-                <LikeIcon
-                  width="16"
-                  height="16"
-                  onClick={handleClickLike}
-                />
-              )}
-              <Content>0</Content>
-            </ContainerCol>
-            <ContainerCol
-              type="icon"
-              style={{ position: "relative" }}
-            >
-              <MeetballIcon
-                width="16"
-                height="16"
-                onClick={handleClickMeetball}
-              />
-              <br />
-              {isMeetballClick && (
-                <MeetballSelect
-                  path={PATH.COMMUNITY_UPDATE(
-                    board.ariticleId
-                  )}
-                />
-              )}
-            </ContainerCol>
-          </ContainerRow>
-        </TitleContainer>
-        <ContainerRow type="center">
-          <Profile />
-          <Content>{board.memberId}</Content>
-        </ContainerRow>
-        <Content>{board.createTime} 작성</Content>
-        <ContentContainer>
-          <Content type="black">
-            {board.content}
-          </Content>
-          {type === "qna" && (
-            <ContainerRow type="center">
-              <QnaImg />
-              <ContainerCol>
-                <CourseName>
-                  {board.lectureTitle}
-                </CourseName>
+      {initialBoard && (
+        <Container>
+          <TitleContainer>
+            <Title>{initialBoard.title}</Title>
+            <ContainerRow>
+              <ContainerCol type="icon">
+                {initialBoard.isScrapped ? (
+                  <BookMarkIcon
+                    width="16"
+                    height="16"
+                    fill={color.yellow}
+                    onClick={handleClickBookMark}
+                  />
+                ) : (
+                  <BookMarkIcon
+                    width="16"
+                    height="16"
+                    onClick={handleClickBookMark}
+                  />
+                )}
                 <Content>
-                  {board.courseTitle}
+                  {initialBoard.scrapCount}
                 </Content>
               </ContainerCol>
+              <ContainerCol type="icon">
+                {initialBoard.isLiked ? (
+                  <LikeIcon
+                    fill={color.pinkRed}
+                    stroke="none"
+                    width="16"
+                    height="16"
+                    onClick={handleClickLike}
+                  />
+                ) : (
+                  <LikeIcon
+                    width="16"
+                    height="16"
+                    onClick={handleClickLike}
+                  />
+                )}
+                <Content>
+                  {initialBoard.likeCount}
+                </Content>
+              </ContainerCol>
+              <ContainerCol
+                type="icon"
+                style={{ position: "relative" }}
+              >
+                <MeetballIcon
+                  width="16"
+                  height="16"
+                  onClick={handleClickMeetball}
+                />
+                <br />
+                {isMeetballClick && (
+                  <MeetballSelect
+                    path={PATH.COMMUNITY_UPDATE(
+                      initialBoard.ariticleId
+                    )}
+                  />
+                )}
+              </ContainerCol>
             </ContainerRow>
-          )}
-          <ContainerRow>
-            <Button
-              text
-              onClick={handleClickViewReview}
-            >
-              {!viewReview ? (
-                <ChevronDownIcon
-                  width="16"
-                  height="16"
-                />
-              ) : (
-                <ChevronUpIcon
-                  width="16"
-                  height="16"
-                />
-              )}{" "}
-              {board.commentCount}개 댓글 보기
-            </Button>
-            <Button
-              text
-              onClick={handleClickGoWriteReview}
-            >
-              <ChatIcon width="16" height="16" />{" "}
-              댓글 작성하기
-            </Button>
+          </TitleContainer>
+          <ContainerRow type="center">
+            <Profile />
+            <Content>
+              {initialBoard.memberId}
+            </Content>
           </ContainerRow>
-        </ContentContainer>
-        {writeReview && <RegistReview />}
-        {viewReview &&
-          board.comments.map((review) => (
-            <Review content={review.content} />
-          ))}
-      </Container>
+          <Content>
+            {initialBoard.createTime} 작성
+          </Content>
+          <ContentContainer>
+            <Content type="black">
+              {initialBoard.content}
+            </Content>
+            {type === "qna" && (
+              <ContainerRow type="center">
+                <QnaImg />
+                <ContainerCol>
+                  <CourseName>
+                    {initialBoard.lectureTitle}
+                  </CourseName>
+                  <Content>
+                    {initialBoard.courseTitle}
+                  </Content>
+                </ContainerCol>
+              </ContainerRow>
+            )}
+            <ContainerRow>
+              <Button
+                text
+                onClick={handleClickViewReview}
+              >
+                {!viewReview ? (
+                  <ChevronDownIcon
+                    width="16"
+                    height="16"
+                  />
+                ) : (
+                  <ChevronUpIcon
+                    width="16"
+                    height="16"
+                  />
+                )}{" "}
+                {initialBoard.commentCount}개 댓글
+                보기
+              </Button>
+              <Button
+                text
+                onClick={handleClickGoWriteReview}
+              >
+                <ChatIcon
+                  width="16"
+                  height="16"
+                />{" "}
+                댓글 작성하기
+              </Button>
+            </ContainerRow>
+          </ContentContainer>
+          {writeReview && <RegistReview />}
+          {viewReview &&
+            initialBoard.comments.map(
+              (review) => (
+                <Review
+                  content={review.content}
+                />
+              )
+            )}
+        </Container>
+      )}
     </DetailBlock>
   );
 };

--- a/src/pages/Service/CommunityRegist/CommunityRegistPage.jsx
+++ b/src/pages/Service/CommunityRegist/CommunityRegistPage.jsx
@@ -1,11 +1,18 @@
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
-import { Container, StyledInput } from "./CommunityRegistPage.style";
+import {
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import {
+  Container,
+  StyledInput,
+} from "./CommunityRegistPage.style";
 import RegistNav from "@components/community/Regist/RegistNav";
 import RegistCourse from "@components/community/Regist/RegistCourse";
 import ToastQna from "@components/community/Regist/ToastQna";
 import useQnaStore from "@stores/Community/QnaStore";
 import useConcernStore from "@stores/Community/ConcernStore";
+import { PATH } from "@router/Constants";
 const CommunityRegistPage = () => {
   const { writeConcern } = useConcernStore();
   const { writeQna } = useQnaStore();
@@ -17,11 +24,15 @@ const CommunityRegistPage = () => {
     "Q&A": "🙋Q&A",
     concern: "🤔고민",
   };
-  const [selected, setSelected] = useState(typeMap[type]);
+  const [selected, setSelected] = useState(
+    typeMap[type]
+  );
   const [title, setTitle] = useState("");
-  const [selectedCourse, setSelectedCourse] = useState("강좌를 선택해주세요.");
+  const [selectedCourse, setSelectedCourse] =
+    useState("강좌를 선택해주세요.");
   const [selectedLecture, setSelectedLecture] =
     useState("강의를 선택해주세요.");
+  const navigate = useNavigate();
   useEffect(() => {
     setTitle("");
   }, [selected]);
@@ -50,6 +61,11 @@ const CommunityRegistPage = () => {
     setTitle("");
     setSelectedCourse("강좌를 선택해주세요.");
     setSelectedLecture("강의를 선택해주세요.");
+    navigate(
+      PATH.COMMUNITY(
+        type === "Q&A" ? "Q&A" : "concern"
+      )
+    );
   };
   return (
     <Container>

--- a/src/pages/Service/CommunityRegist/CommunityRegistPage.jsx
+++ b/src/pages/Service/CommunityRegist/CommunityRegistPage.jsx
@@ -63,8 +63,8 @@ const CommunityRegistPage = () => {
     setSelectedLecture("강의를 선택해주세요.");
     navigate(
       PATH.COMMUNITY(
-        type === "Q&A" ? "Q&A" : "concern"
-      )
+        selected === "🙋Q&A" ? "Q&A" : "concern"
+      ) + `?keyword=&criteria=&pageNo=1`
     );
   };
   return (

--- a/src/stores/Community/ConcernStore.js
+++ b/src/stores/Community/ConcernStore.js
@@ -12,23 +12,36 @@ import {
 } from "@apis/community/concernApi";
 const useConcernStore = create((set) => ({
   concern: null,
-  concernList: [],
+  concernList: {},
   likedConcerns: [],
   scrappedConcerns: [],
 
   //고민 목록 가져오기
-  fetchConcernList: async (keyword, criteria, pageNo) => {
+  fetchConcernList: async (
+    keyword,
+    criteria,
+    pageNo
+  ) => {
     try {
-      const response = await getConcernList(keyword, criteria, pageNo);
+      const response = await getConcernList(
+        keyword,
+        criteria,
+        pageNo
+      );
       set({ concernList: response.data });
     } catch (e) {
-      console.error("고민 목록 가져오기 실패 : ", e);
+      console.error(
+        "고민 목록 가져오기 실패 : ",
+        e
+      );
     }
   },
   //고민 상세보기
   fetchConcernDetail: async (articleId) => {
     try {
-      const response = await getConcernDetail(articleId);
+      const response = await getConcernDetail(
+        articleId
+      );
       set({ concern: response.data });
     } catch (e) {
       console.error("고민 상세보기 실패: ", e);
@@ -36,10 +49,12 @@ const useConcernStore = create((set) => ({
   },
   //고민글 작성
   writeConcern: async (article) => {
-    await writeConcern(article).then((response) => {
-      console.log(response);
-      return response.data;
-    });
+    await writeConcern(article).then(
+      (response) => {
+        console.log(response);
+        return response.data;
+      }
+    );
   },
   //고민 수정
   updateConcern: async (articleId, article) => {
@@ -55,7 +70,10 @@ const useConcernStore = create((set) => ({
       const response = await concernLiked();
       set({ likedConcerns: response.data });
     } catch (e) {
-      console.error("좋아요한 리스트 가져오기 실패: ", e);
+      console.error(
+        "좋아요한 리스트 가져오기 실패: ",
+        e
+      );
     }
   },
   //스크랩 목록 가져오기
@@ -64,7 +82,10 @@ const useConcernStore = create((set) => ({
       const response = await concernScrapped();
       set({ scrappedConcerns: response.data });
     } catch (e) {
-      console.error("스크랩한 리스트 가져오기 실패: ", e);
+      console.error(
+        "스크랩한 리스트 가져오기 실패: ",
+        e
+      );
     }
   },
   //고민 좋아요

--- a/src/stores/Community/QnaStore.js
+++ b/src/stores/Community/QnaStore.js
@@ -12,23 +12,36 @@ import {
 } from "@apis/community/QnaApi";
 const useQnaStore = create((set, get) => ({
   qna: null,
-  qnaList: [],
+  qnaList: {},
   likedQnas: [],
   scrappedQnas: [],
 
   //질문 목록 가져오기
-  fetchQnaList: async (keyword, criteria, pageNo) => {
+  fetchQnaList: async (
+    keyword,
+    criteria,
+    pageNo
+  ) => {
     try {
-      const response = await getQuestionList(keyword, criteria, pageNo);
+      const response = await getQuestionList(
+        keyword,
+        criteria,
+        pageNo
+      );
       set({ qnaList: response.data });
     } catch (e) {
-      console.error("질문 목록 가져오기 실패 : ", e);
+      console.error(
+        "질문 목록 가져오기 실패 : ",
+        e
+      );
     }
   },
   //질문 상세보기
   fetchQnaDetail: async (articleId) => {
     try {
-      const response = await getQuestionDetail(articleId);
+      const response = await getQuestionDetail(
+        articleId
+      );
       set({ qna: response.data });
     } catch (e) {
       console.error("질문 상세보기 실패: ", e);
@@ -36,9 +49,11 @@ const useQnaStore = create((set, get) => ({
   },
   //질문글 작성
   writeQna: async (article) => {
-    await writeQuestion(article).then((response) => {
-      return response.data;
-    });
+    await writeQuestion(article).then(
+      (response) => {
+        return response.data;
+      }
+    );
   },
   //질문 수정
   updateQna: async (articleId, article) => {
@@ -54,7 +69,10 @@ const useQnaStore = create((set, get) => ({
       const response = await QuestionLiked();
       set({ likedQnas: response.data });
     } catch (e) {
-      console.error("좋아요한 리스트 가져오기 실패: ", e);
+      console.error(
+        "좋아요한 리스트 가져오기 실패: ",
+        e
+      );
     }
   },
   //스크랩 목록 가져오기
@@ -63,7 +81,10 @@ const useQnaStore = create((set, get) => ({
       const response = await QuestionScrapped();
       set({ scrappedQnas: response.data });
     } catch (e) {
-      console.error("스크랩한 리스트 가져오기 실패: ", e);
+      console.error(
+        "스크랩한 리스트 가져오기 실패: ",
+        e
+      );
     }
   },
   //질문 좋아요


### PR DESCRIPTION
### #️⃣연관된 이슈

- resolve #90

### 📝상세 내용

- 기존에 CommunityBoardPage에서 리스트를 fetch받아오던 로직을 CommunityPage에서 fetch받아오도록 수정
- 위 방식에서는 비동기 문제를 return문에서 boardList가 null이 아닌경우에 렌더링 하도록 조건부 렌더링으로 해결
- 게시글 등록 후 유형에 맞는 리스트로 넘어오도록 수정
- 게시글 제목 클릭 시 상세보기로 이동
- 기존에 CommunityDetailPage에서 type에 따라서 게시글을 fetch받아오던 로직을 Card에서 state로 board객체를 보내서 비동기 문제를 해결
