### PR TITLE
FEAT : 커뮤니티 검색 및 페이지 이동 구현

### DIFF
--- a/src/components/common/pagination/Pagination.jsx
+++ b/src/components/common/pagination/Pagination.jsx
@@ -16,6 +16,7 @@ const Pagination = ({
   itemCountPerPage,
   pageCount,
   currentPage,
+  setPageNo,
   type,
   link,
 }) => {
@@ -33,7 +34,15 @@ const Pagination = ({
     if (currentPage < start)
       setStart((prev) => prev - pageCount);
   }, [currentPage, pageCount, start]);
-
+  const handleClickPrev = () => {
+    setPageNo(start - 1);
+  };
+  const handleClickPage = (pageNo) => {
+    setPageNo(pageNo);
+  };
+  const handleClickNext = () => {
+    setPageNo(start + pageCount);
+  };
   return (
     <Flex
       justify="center"
@@ -46,7 +55,10 @@ const Pagination = ({
             to={link + `&pageNo=${start - 1}`}
           >
             <li>
-              <Button text>
+              <Button
+                text
+                onClick={handleClickPrev}
+              >
                 <ChevronLeftIcon
                   width="16"
                   height="16"
@@ -67,7 +79,14 @@ const Pagination = ({
                       {start + idx}
                     </ActiveButton>
                   ) : (
-                    <Button text>
+                    <Button
+                      text
+                      onClick={() =>
+                        handleClickPage(
+                          start + idx
+                        )
+                      }
+                    >
                       {start + idx}
                     </Button>
                   )}
@@ -84,7 +103,10 @@ const Pagination = ({
             }
           >
             <li>
-              <Button text>
+              <Button
+                text
+                onClick={handleClickNext}
+              >
                 <ChevronRightIcon
                   width="16"
                   height="16"

--- a/src/components/common/searchbar/SearchBar.jsx
+++ b/src/components/common/searchbar/SearchBar.jsx
@@ -10,7 +10,12 @@ import {
 import Select from "@components/common/select/Select";
 import useCommonStore from "@stores/common/CommonStore";
 import { useNavigate } from "react-router-dom";
-const SearchBar = ({ link, search, type }) => {
+const SearchBar = ({
+  link,
+  search,
+  type,
+  setPageNo,
+}) => {
   const ref = useRef(null);
   const [selected, setSelected] =
     useState("최신순");
@@ -43,7 +48,8 @@ const SearchBar = ({ link, search, type }) => {
     }
   };
   useEffect(() => {
-    search(keyword, searchOptions[criteria]);
+    search(keyword, criteria);
+    setPageNo(1);
   }, [keyword, criteria]);
   useEffect(() => {
     if (pendingNavigation) {
@@ -70,7 +76,7 @@ const SearchBar = ({ link, search, type }) => {
         ref={ref}
       ></StyledSearchBar>
       <Select
-        options={Object.keys(searchOptions)}
+        options={searchOptions}
         selectedValue={selected}
         setSelectedValue={setSelected}
         width={"6rem"}

--- a/src/components/common/searchbar/SearchBar.jsx
+++ b/src/components/common/searchbar/SearchBar.jsx
@@ -1,35 +1,76 @@
-import { SearchBarContainer, StyledSearchBar } from "./Searchbar.style";
-import { useState, useEffect } from "react";
+import {
+  SearchBarContainer,
+  StyledSearchBar,
+} from "./Searchbar.style";
+import {
+  useState,
+  useEffect,
+  useRef,
+} from "react";
 import Select from "@components/common/select/Select";
 import useCommonStore from "@stores/common/CommonStore";
 import { useNavigate } from "react-router-dom";
-const SearchBar = ({ link }) => {
-  const [selected, setSelected] = useState("최신순");
-  const [pendingNavigation, setPendingNavigation] = useState(false);
+const SearchBar = ({ link, search, type }) => {
+  const ref = useRef(null);
+  const [selected, setSelected] =
+    useState("최신순");
+  const [
+    pendingNavigation,
+    setPendingNavigation,
+  ] = useState(false);
   const navigate = useNavigate();
-  const searchOptions = ["최신순", "조회수순", "댓글순", "좋아요순"];
-  const { keyword, setKeyword } = useCommonStore();
+  const searchOptions = {
+    최신순: "createTime",
+    조회수순: "hit",
+    스크랩순: "scrapCount",
+    좋아요순: "likeCount",
+  };
+  const {
+    keyword,
+    setKeyword,
+    criteria,
+    setCriteria,
+  } = useCommonStore();
   const handleKeyDown = (e) => {
-    if (e.key === "Enter" && e.nativeEvent.isComposing === false) {
+    if (
+      e.key === "Enter" &&
+      e.nativeEvent.isComposing === false
+    ) {
       setKeyword(e.target.value);
       setPendingNavigation(true);
       e.preventDefault();
+      ref.current.value = "";
     }
   };
+  useEffect(() => {
+    search(keyword, searchOptions[criteria]);
+  }, [keyword, criteria]);
   useEffect(() => {
     if (pendingNavigation) {
       navigate(link);
       setPendingNavigation(false);
     }
   }, [pendingNavigation, navigate, link]);
+  useEffect(() => {
+    return () => {
+      setKeyword("");
+      setCriteria("");
+    };
+  }, [setKeyword]);
+  useEffect(() => {
+    setKeyword("");
+    setCriteria("");
+    setSelected("최신순");
+  }, [type]);
   return (
     <SearchBarContainer>
       <StyledSearchBar
         placeholder="제목, 내용을 입력해주세요"
         onKeyDown={handleKeyDown}
+        ref={ref}
       ></StyledSearchBar>
       <Select
-        options={searchOptions}
+        options={Object.keys(searchOptions)}
         selectedValue={selected}
         setSelectedValue={setSelected}
         width={"6rem"}

--- a/src/components/common/select/Select.jsx
+++ b/src/components/common/select/Select.jsx
@@ -1,5 +1,8 @@
 import { useState, useEffect } from "react";
-import { ChevronUpIcon, ChevronDownIcon } from "@assets/svg/icons";
+import {
+  ChevronUpIcon,
+  ChevronDownIcon,
+} from "@assets/svg/icons";
 import useCommonStore from "@stores/common/CommonStore";
 import {
   StyledSelect,
@@ -10,9 +13,19 @@ import {
 } from "./Select.style";
 import { useNavigate } from "react-router-dom";
 
-const Select = ({ options, selectedValue, setSelectedValue, width, link }) => {
-  const [isShowOptions, setIsShowOptions] = useState(false);
-  const [pendingNavigation, setPendingNavigation] = useState(false);
+const Select = ({
+  options,
+  selectedValue,
+  setSelectedValue,
+  width,
+  link,
+}) => {
+  const [isShowOptions, setIsShowOptions] =
+    useState(false);
+  const [
+    pendingNavigation,
+    setPendingNavigation,
+  ] = useState(false);
   const { setCriteria } = useCommonStore();
   const navigate = useNavigate();
 
@@ -22,7 +35,7 @@ const Select = ({ options, selectedValue, setSelectedValue, width, link }) => {
 
   const handleOptionClick = (option) => {
     setSelectedValue(option);
-    setCriteria(option);
+    setCriteria(options[option]);
     setIsShowOptions(false);
     setPendingNavigation(true);
   };
@@ -35,20 +48,40 @@ const Select = ({ options, selectedValue, setSelectedValue, width, link }) => {
   return (
     <StyledSelect style={{ width }}>
       <Selected onClick={handleClickOptions}>
-        <SelectedValue>{selectedValue}</SelectedValue>
+        <SelectedValue>
+          {selectedValue}
+        </SelectedValue>
         {isShowOptions ? (
-          <ChevronUpIcon width="16" height="12" class="bi bi-chevron-up" />
+          <ChevronUpIcon
+            width="16"
+            height="12"
+            class="bi bi-chevron-up"
+          />
         ) : (
-          <ChevronDownIcon width="16" height="12" class="bi bi-chevron-down" />
+          <ChevronDownIcon
+            width="16"
+            height="12"
+            class="bi bi-chevron-down"
+          />
         )}
       </Selected>
       {}
-      <Options active={isShowOptions} style={{ width }}>
-        {options.map((option, index) => (
-          <Option key={index} onClick={() => handleOptionClick(option)}>
-            {option}
-          </Option>
-        ))}
+      <Options
+        active={isShowOptions}
+        style={{ width }}
+      >
+        {Object.keys(options).map(
+          (option, index) => (
+            <Option
+              key={index}
+              onClick={() =>
+                handleOptionClick(option)
+              }
+            >
+              {option}
+            </Option>
+          )
+        )}
       </Options>
     </StyledSelect>
   );

--- a/src/pages/Service/Community/CommunityPage.jsx
+++ b/src/pages/Service/Community/CommunityPage.jsx
@@ -13,7 +13,12 @@ import { useState, useEffect } from "react";
 import useConcernStore from "@stores/Community/ConcernStore";
 import useQnaStore from "@stores/Community/QnaStore";
 const CommunityPage = () => {
-  const { keyword, criteria } = useCommonStore();
+  const {
+    keyword,
+    criteria,
+    setKeyword,
+    setCriteria,
+  } = useCommonStore();
   const location = useLocation();
   const type = location.pathname.split("/")[2];
   const params = new URLSearchParams(
@@ -36,6 +41,13 @@ const CommunityPage = () => {
       );
     }
   }, [type]);
+  const boardSearch = (keyword, criteria) => {
+    if (type === "Q&A") {
+      fetchQnaList(keyword, criteria, 0);
+    } else {
+      fetchConcernList(keyword, criteria, 0);
+    }
+  };
   return (
     <Container>
       <NavBar />
@@ -45,6 +57,8 @@ const CommunityPage = () => {
             PATH.COMMUNITY(type) +
             `?keyword=${keyword}&criteria=${criteria}&pageNo=1`
           }
+          search={boardSearch}
+          type={type}
         />
         <CommunityBoardPage
           type={type}

--- a/src/pages/Service/Community/CommunityPage.jsx
+++ b/src/pages/Service/Community/CommunityPage.jsx
@@ -13,12 +13,7 @@ import { useState, useEffect } from "react";
 import useConcernStore from "@stores/Community/ConcernStore";
 import useQnaStore from "@stores/Community/QnaStore";
 const CommunityPage = () => {
-  const {
-    keyword,
-    criteria,
-    setKeyword,
-    setCriteria,
-  } = useCommonStore();
+  const { keyword, criteria } = useCommonStore();
   const location = useLocation();
   const type = location.pathname.split("/")[2];
   const params = new URLSearchParams(
@@ -40,7 +35,7 @@ const CommunityPage = () => {
         pageNo - 1
       );
     }
-  }, [type]);
+  }, [type, pageNo]);
   const boardSearch = (keyword, criteria) => {
     if (type === "Q&A") {
       fetchQnaList(keyword, criteria, 0);
@@ -59,6 +54,7 @@ const CommunityPage = () => {
           }
           search={boardSearch}
           type={type}
+          setPageNo={setPageNo}
         />
         <CommunityBoardPage
           type={type}
@@ -78,6 +74,7 @@ const CommunityPage = () => {
           itemCountPerPage={10}
           pageCount={5}
           currentPage={pageNo}
+          setPageNo={setPageNo}
           type={type}
           link={
             PATH.COMMUNITY(type) +


### PR DESCRIPTION
### #️⃣연관된 이슈

- resolve #97 

### 📝상세 내용

- 검색창에 내용 검색 후 엔터 입력 시 검색 내용 결과물 반환 및 검색창 빈칸으로 초기화
- 정렬조건 선택 시 조건에 맞게 정렬 및 페이지 1로 이동
- 게시판 타입 바뀌면 검색창 및 정렬 조건 초기화
- 페이지 이동 시 검색 내용 및 검색 조건 초기화
- 페이지 이동 시 해당 페이지에 해당하는 리스트 반환
