### PR TITLE
Feat: 마이페이지 회원탈퇴 구현

### DIFF
--- a/src/apis/members/membersApi.js
+++ b/src/apis/members/membersApi.js
@@ -27,6 +27,9 @@ export const patchMemberInfo = (data) => {
   return axiosInstance.patch(END_POINT.MEMBER, data);
 };
 
+export const deleteMember = () => {
+  return axiosInstance.delete(END_POINT.MEMBER);
+};
 // 보류중
 export const validateDuplicateNickname = (nickname) => {
   return axiosInstance.get(`/check-nickname?nickname=${nickname}`);
@@ -39,8 +42,4 @@ export const login = (username, password) => {
   form.append("password", password);
 
   return axiosInstance.post(END_POINT.LOGIN, form, header);
-};
-
-export const deleteMember = (memberId) => {
-  return axiosInstance.delete(END_POINT.MEMBER_DETAIL(memberId));
 };

--- a/src/components/common/button/Button.style.js
+++ b/src/components/common/button/Button.style.js
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import { color } from "../../../styles/style";
 
 export const StyledButton = styled.button`
+  width: ${(props) => props.width};
   height: 3rem;
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;

--- a/src/components/common/modal/confirmModal/ConfirmModal.jsx
+++ b/src/components/common/modal/confirmModal/ConfirmModal.jsx
@@ -1,0 +1,44 @@
+import Button from "@components/common/button/Button";
+import { Flex } from "@components/common/flex/Flex";
+import {
+  ModalCautionMessage,
+  ModalMessage,
+  ModalTitle,
+  customModalStyles,
+} from "@components/common/modal/confirmModal/ConfirmModal.style";
+import Modal from "react-modal";
+
+const ConfirmModal = ({
+  title,
+  cautions,
+  messages,
+  confirm,
+  close,
+  isOpen,
+}) => {
+  return (
+    <>
+      <Modal isOpen={isOpen} closeTimeoutMS={150} style={customModalStyles}>
+        <ModalTitle>{title}</ModalTitle>
+        <Flex direction="column" gap="0.1rem" align="center">
+          {cautions?.map((caution) => (
+            <ModalCautionMessage>{caution}</ModalCautionMessage>
+          ))}
+          {messages?.map((message) => (
+            <ModalMessage>{message}</ModalMessage>
+          ))}
+        </Flex>
+        <Flex width="100%" gap="1rem">
+          <Button fill width={"100%"} onClick={close.onClick}>
+            {close.text}
+          </Button>
+          <Button outline width={"100%"} onClick={confirm.onClick}>
+            {confirm.text}
+          </Button>
+        </Flex>
+      </Modal>
+    </>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/common/modal/confirmModal/ConfirmModal.style.js
+++ b/src/components/common/modal/confirmModal/ConfirmModal.style.js
@@ -15,15 +15,6 @@ export const ModalMessage = styled.p`
   color: ${color.black};
 `;
 
-export const Dim = styled.div`
-  background-color: ${color.black};
-  width: 100vh;
-  height: 100vh;
-  opacity: 0.25;
-  position: absolute;
-  top: 0;
-  left: 0;
-`;
 export const customModalStyles = {
   overlay: {
     color: "black",

--- a/src/components/common/modal/confirmModal/ConfirmModal.style.js
+++ b/src/components/common/modal/confirmModal/ConfirmModal.style.js
@@ -1,0 +1,49 @@
+import { color, typo } from "@styles/style";
+import styled from "styled-components";
+export const ModalTitle = styled.p`
+  font: ${typo.titleSm700};
+  color: ${color.black};
+`;
+
+export const ModalCautionMessage = styled.p`
+  font: ${typo.bodyRg700};
+  color: ${color.pinkRed};
+`;
+
+export const ModalMessage = styled.p`
+  font: ${typo.bodyRg400};
+  color: ${color.black};
+`;
+
+export const Dim = styled.div`
+  background-color: ${color.black};
+  width: 100vh;
+  height: 100vh;
+  opacity: 0.25;
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+export const customModalStyles = {
+  overlay: {
+    color: "black",
+    backgroundColor: "rgba(0.17, 0.17, 0.17, 0.25)",
+  },
+  content: {
+    border: "none",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    height: "fit-content",
+    alignItems: "center",
+    gap: "1rem",
+    width: "fit-content",
+    padding: "1.5rem",
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    borderRadius: "1rem",
+    backgroundColor: "white",
+  },
+};

--- a/src/components/common/modal/confirmModal/MemberDeleteConfirmModal.jsx
+++ b/src/components/common/modal/confirmModal/MemberDeleteConfirmModal.jsx
@@ -1,0 +1,42 @@
+import Button from "@components/common/button/Button";
+import { Flex } from "@components/common/flex/Flex";
+import {
+  ModalCautionMessage,
+  ModalMessage,
+  ModalTitle,
+  customModalStyles,
+} from "@components/common/modal/confirmModal/ConfirmModal.style";
+import Modal from "react-modal";
+
+const MemberDeleteConfirmModal = ({
+  title,
+  cautions,
+  messages,
+  confirm,
+  close,
+  isOpen,
+}) => {
+  return (
+    <Modal isOpen={isOpen} closeTimeoutMS={150} style={customModalStyles}>
+      <ModalTitle>{title}</ModalTitle>
+      <Flex direction="column" gap="0.1rem" align="center">
+        {cautions?.map((caution) => (
+          <ModalCautionMessage>{caution}</ModalCautionMessage>
+        ))}
+        {messages?.map((message) => (
+          <ModalMessage>{message}</ModalMessage>
+        ))}
+      </Flex>
+      <Flex width="100%" gap="1rem">
+        <Button outline width={"100%"} onClick={confirm.onClick}>
+          {confirm.text}
+        </Button>
+        <Button fill width={"100%"} onClick={close.onClick}>
+          {close.text}
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default MemberDeleteConfirmModal;

--- a/src/pages/Service/MyPage/MyPage.jsx
+++ b/src/pages/Service/MyPage/MyPage.jsx
@@ -1,13 +1,44 @@
 import { PageTitle } from "@components/common/page/PageTitle";
 import { MyPageContainer, Tab } from "./MyPage.style";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import PageLayout from "@components/common/page/PageLayout";
 import { PATH } from "@router/Constants";
+import { useState } from "react";
+import ConfirmModal from "@components/common/modal/confirmModal/ConfirmModal";
+import { deleteMember } from "@apis/members/membersApi";
+import { useMutation } from "@tanstack/react-query";
+import MemberDeleteConfirmModal from "@components/common/modal/confirmModal/MemberDeleteConfirmModal";
 
 const MyPage = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+  const outMemberMutation = useMutation({
+    mutationFn: deleteMember,
+    onSuccess: () => {
+      console.log("성공");
+    },
+    onError: (error) => {
+      console.log("onError", error);
+    },
+  });
+
+  const handleConfirmBtnClick = () => {
+    outMemberMutation.mutate();
+    setIsOpen(false);
+    navigate(PATH.ROOT);
+  };
+
   return (
     <PageLayout>
       <PageTitle>마이페이지</PageTitle>
+      <MemberDeleteConfirmModal
+        isOpen={isOpen}
+        title={"정말 탈퇴하실 건가요?"}
+        cautions={["그동안 올렸던 질문들과 강좌 수강 기록이 사라져요"]}
+        messages={["그래도 회원 탈퇴하시겠어요?"]}
+        confirm={{ text: "탈퇴하기", onClick: handleConfirmBtnClick }}
+        close={{ text: "닫기", onClick: () => setIsOpen(false) }}
+      />
       <MyPageContainer>
         <Link to={PATH.MY_COURSE}>
           <Tab>나의 강좌</Tab>
@@ -21,9 +52,7 @@ const MyPage = () => {
         <Link to={PATH.MY_NOTIFICATION_SETTING}>
           <Tab>알림</Tab>
         </Link>
-        <Link to={PATH.MEMBER_DELETE}>
-          <Tab>회원탈퇴</Tab>
-        </Link>
+        <Tab onClick={() => setIsOpen(true)}>회원탈퇴</Tab>
       </MyPageContainer>
     </PageLayout>
   );

--- a/src/pages/Service/MyPage/MyPage.jsx
+++ b/src/pages/Service/MyPage/MyPage.jsx
@@ -8,10 +8,12 @@ import ConfirmModal from "@components/common/modal/confirmModal/ConfirmModal";
 import { deleteMember } from "@apis/members/membersApi";
 import { useMutation } from "@tanstack/react-query";
 import MemberDeleteConfirmModal from "@components/common/modal/confirmModal/MemberDeleteConfirmModal";
+import { useLoginStore } from "@stores/member/loginStore";
 
 const MyPage = () => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
+  const setIsLogin = useLoginStore((state) => state.setIsLogin);
   const outMemberMutation = useMutation({
     mutationFn: deleteMember,
     onSuccess: () => {
@@ -25,6 +27,7 @@ const MyPage = () => {
   const handleConfirmBtnClick = () => {
     outMemberMutation.mutate();
     setIsOpen(false);
+    setIsLogin(false);
     navigate(PATH.ROOT);
   };
 


### PR DESCRIPTION
### #️⃣연관된 이슈

- resolve #119 

### 📝상세 내용
- 회원탈퇴시 로그아웃
- 회원탈퇴 확인 모달 구현
- 확인 모달 추상화

### `ConfirmModal` 사용법
‼️‼️‼️ `MyPage.jsx` 에서 `MemberDeleteConfirmModal` 사용한 것과 똑같이 사용하면 됨  ‼️‼️‼️
‼️‼️‼️ 아래는 `ConfirmModal` 코드랑 `props`가 뭘 의미하는지 사진 ‼️‼️‼️

```js
const ConfirmModal = ({
  title,
  cautions,
  messages,
  confirm,
  close,
  isOpen,
}) => {
  return (
      <Modal isOpen={isOpen} closeTimeoutMS={150} style={customModalStyles}>
        <ModalTitle>{title}</ModalTitle>
        <Flex direction="column" gap="0.1rem" align="center">
          {cautions?.map((caution) => (
            <ModalCautionMessage>{caution}</ModalCautionMessage>
          ))}
          {messages?.map((message) => (
            <ModalMessage>{message}</ModalMessage>
          ))}
        </Flex>
        <Flex width="100%" gap="1rem">
          <Button fill width={"100%"} onClick={close.onClick}>
            {close.text}
          </Button>
          <Button outline width={"100%"} onClick={confirm.onClick}>
            {confirm.text}
          </Button>
        </Flex>
      </Modal>
  );
};
```
<img width="944" alt="image" src="https://github.com/user-attachments/assets/8f880b90-0cb1-4037-a0e5-6b65ca8d7938">
